### PR TITLE
Update version for TestContainers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,13 +107,13 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.13.0</version>
+            <version>1.15.0-rc2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>1.13.0</version>
+            <version>1.15.0-rc2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
TestContainers doesn't work because of [this](https://github.com/testcontainers/testcontainers-java/issues/3166) issue. It has to be updated to the latest version.