### PR TITLE
Fix PostgreSQLContainer initialization problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,13 +111,13 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.15.0-rc2</version>
+            <version>1.16.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>1.15.0-rc2</version>
+            <version>1.16.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/com/studyolle/infra/ContainerBaseTest.java
+++ b/src/test/java/com/studyolle/infra/ContainerBaseTest.java
@@ -7,7 +7,7 @@ public abstract class ContainerBaseTest {
     static final PostgreSQLContainer POSTGRE_SQL_CONTAINER;
 
     static {
-        POSTGRE_SQL_CONTAINER = new PostgreSQLContainer();
+        POSTGRE_SQL_CONTAINER = new PostgreSQLContainer<>("postgres:latest");
         POSTGRE_SQL_CONTAINER.start();
     }
 


### PR DESCRIPTION
Testcontainers 1.15 부터 Deprecated 된 PostgreSQLContainer 생성자 방식이 ContainerBaseTest.java에 있어서 테스트 시 오류가 납니다. Testcontainers를 1.16으로 업데이트하고 올바른 생성 방식으로 수정했습니다.

workflow에 test step을 추가하면 좋을듯 합니다.