### PR TITLE
Block /login from authenticated users

### DIFF
--- a/src/main/java/com/studyolle/infra/config/SecurityConfig.java
+++ b/src/main/java/com/studyolle/infra/config/SecurityConfig.java
@@ -26,13 +26,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests()
-                .mvcMatchers("/", "/login", "/sign-up", "/check-email-token",
+                .mvcMatchers("/login").not().fullyAuthenticated()
+                .mvcMatchers("/", "/sign-up", "/check-email-token",
                         "/email-login", "/login-by-email", "/search/study").permitAll()
                 .mvcMatchers(HttpMethod.GET, "/profile/*").permitAll()
                 .anyRequest().authenticated();
 
         http.formLogin()
-                .loginPage("/login").permitAll();
+                .loginPage("/login");
 
         http.logout()
                 .logoutSuccessUrl("/");

--- a/src/test/java/com/studyolle/modules/main/MainControllerTest.java
+++ b/src/test/java/com/studyolle/modules/main/MainControllerTest.java
@@ -4,6 +4,7 @@ import com.studyolle.infra.ContainerBaseTest;
 import com.studyolle.infra.MockMvcTest;
 import com.studyolle.modules.account.AccountRepository;
 import com.studyolle.modules.account.AccountService;
+import com.studyolle.modules.account.WithAccount;
 import com.studyolle.modules.account.form.SignUpForm;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,7 +17,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
 import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -86,6 +88,15 @@ class MainControllerTest extends ContainerBaseTest {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/"))
                 .andExpect(unauthenticated());
+    }
+
+    @WithAccount("whiteship")
+    @DisplayName("인증된 사용자가 로그인 페이지 접근시 에러")
+    @Test
+    void login_access_fail() throws Exception {
+        mockMvc.perform(get("/login"))
+                .andDo(print())
+                .andExpect(status().isForbidden());
     }
 
 }


### PR DESCRIPTION
인증된 사용자는 로그인 페이지에 접근할 수 없도록 스프링 시큐리티 설정을 수정합니다.